### PR TITLE
Fix broken links in docs

### DIFF
--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -34,23 +34,23 @@ Staking and validator election process happens on the Ethereum [staking contract
 
 1. Validator calls the [initializeValidator](https://github.com/celer-network/sgn-v2-contracts/blob/a75ac8dc8b/contracts/Staking.sol#L100) on staking contract to initialize itself as a validator, and [updateSgnAddr](https://github.com/celer-network/sgn-v2-contracts/blob/a75ac8dc8b/contracts/SGN.sol#L42) on the sgn contract to set the sgnchain (cosmos-sdk) account address.
 
-2. The current validators catch the `ValidatorNotice` event about [sgn address update](https://github.com/celer-network/sgn-v2-contracts/blob/a75ac8dc8b/contracts/SGN.sol#L54), sync the sgn address to x/staking module and [create an sgn account](https://github.com/celer-network/sgn-v2/blob/3b35212c68/x/sync/keeper/apply.go#L72) for the new validator's sgn address.
+2. The current validators catch the `ValidatorNotice` event about [sgn address update](https://github.com/celer-network/sgn-v2-contracts/blob/a75ac8dc8b/contracts/SGN.sol#L54), sync the sgn address to x/staking module and [create an sgn account](https://github.com/celer-network/sgnv2/blob/3b35212c68/x/sync/keeper/apply.go#L72) for the new validator's sgn address.
 
-3. The new validator then [sync its params](https://github.com/celer-network/sgn-v2/blob/3b35212c68/relayer/eth_staking.go#L54) to x/staking module to [create a new unbonded validator](https://github.com/celer-network/sgn-v2/blob/3b35212c68/x/sync/keeper/apply.go#L80) with required [initial information](https://github.com/celer-network/sgn-v2/blob/3b35212c68/relayer/operator.go#L168-L174) in the sgn chain.
+3. The new validator then [sync its params](https://github.com/celer-network/sgnv2/blob/3b35212c68/relayer/eth_staking.go#L54) to x/staking module to [create a new unbonded validator](https://github.com/celer-network/sgnv2/blob/3b35212c68/x/sync/keeper/apply.go#L80) with required [initial information](https://github.com/celer-network/sgnv2/blob/3b35212c68/relayer/operator.go#L168-L174) in the sgn chain.
 
-4. The new validator then [sync its states](https://github.com/celer-network/sgn-v2/blob/3b35212c68/x/sync/keeper/apply.go#L129) to update its status (e.g., bonded, unbonded), tokens, and shares in the sgnchain.
+4. The new validator then [sync its states](https://github.com/celer-network/sgnv2/blob/3b35212c68/x/sync/keeper/apply.go#L129) to update its status (e.g., bonded, unbonded), tokens, and shares in the sgnchain.
 
-5. At abci.EndBlocker, [the tendermint validator set is updated](https://github.com/celer-network/sgn-v2/blob/3b35212c68/x/staking/keeper/validator.go#L211) to include the new validator with voting power proportional to its tokens.
+5. At abci.EndBlocker, [the tendermint validator set is updated](https://github.com/celer-network/sgnv2/blob/3b35212c68/x/staking/keeper/validator.go#L211) to include the new validator with voting power proportional to its tokens.
 
 ### Delegate and undelegate
 
 1. Delegator calls the [delegate](https://github.com/celer-network/sgn-v2-contracts/blob/a75ac8dc8b/contracts/Staking.sol#L209) or [undelegate](https://github.com/celer-network/sgn-v2-contracts/blob/a75ac8dc8b/contracts/Staking.sol#L249) functions on the staking contract.
 
-2. Validators catch the `DelegationUpdate` event, and [sync the delegator and validator states](https://github.com/celer-network/sgn-v2/blob/3b35212c68/relayer/eth_puller.go#L86-L98) to x/staking module.
+2. Validators catch the `DelegationUpdate` event, and [sync the delegator and validator states](https://github.com/celer-network/sgnv2/blob/3b35212c68/relayer/eth_puller.go#L86-L98) to x/staking module.
 
-3. [Delegation share update](https://github.com/celer-network/sgn-v2/blob/3b35212c68/x/staking/keeper/delegation.go#L104) would trigger staking reward distribution.
+3. [Delegation share update](https://github.com/celer-network/sgnv2/blob/3b35212c68/x/staking/keeper/delegation.go#L104) would trigger staking reward distribution.
 
-4. [Validator states update](https://github.com/celer-network/sgn-v2/blob/3b35212c68/x/staking/keeper/validator.go#L55) may trigger [signer updates](https://github.com/celer-network/sgn-v2/blob/3b35212c68/x/cbridge/keeper/hooks.go#L18-L28) in the bridge contracts.
+4. [Validator states update](https://github.com/celer-network/sgnv2/blob/3b35212c68/x/staking/keeper/validator.go#L55) may trigger [signer updates](https://github.com/celer-network/sgnv2/blob/3b35212c68/x/cbridge/keeper/hooks.go#L18-L28) in the bridge contracts.
 
 ## Liquidity Pool Bridge
 
@@ -67,7 +67,7 @@ High-level flows and notes:
 
 2. SGN catches the [Send](https://github.com/celer-network/sgn-v2-contracts/blob/a75ac8dc8b/contracts/Bridge.sol#L14) event, sync the event to x/cbridge consensus module through the [event syncing](./relayer.md#sync-other-chain-events-to-sgn) flow.
 
-3. The x/cbridge module [applies the Send event](https://github.com/celer-network/sgn-v2/blob/3b35212c68/x/cbridge/keeper/apply.go#L60).
+3. The x/cbridge module [applies the Send event](https://github.com/celer-network/sgnv2/blob/3b35212c68/x/cbridge/keeper/apply.go#L60).
     - If the request fail due to unsupported token, unreachable slippage etc, a withdraw message will be saved for refund later.
     - If the request can go through, the following logics will be applied before a `relay message` is generated to let all validators sign.
         - Calculation of user receiving amount, including the computation of [liquidity curve](../x/cbridge/spec/01_concepts.md#price-curve), base fee according to gas usage ad price, and percentage fee according to config.
@@ -86,7 +86,7 @@ High-level flows and notes:
 
 2. SGN catches the [LiquidityAdded](https://github.com/celer-network/sgn-v2-contracts/blob/a75ac8dc8b/contracts/Pool.sol#L34) event, sync the event to x/cbridge consensus module through the [event syncing](./relayer.md#sync-other-chain-events-to-sgn) flow.
 
-3. The x/cbridge module [applies the LiquidityAdded event](https://github.com/celer-network/sgn-v2/blob/3b35212c68/x/cbridge/keeper/apply.go#L41), records the new liquidity, and sync the liquidity farming status (if enabled).
+3. The x/cbridge module [applies the LiquidityAdded event](https://github.com/celer-network/sgnv2/blob/3b35212c68/x/cbridge/keeper/apply.go#L41), records the new liquidity, and sync the liquidity farming status (if enabled).
 
 These liquidities will be moved around different chains (and earn fees/rewards) along with the transfer process stated above.
 
@@ -94,8 +94,8 @@ These liquidities will be moved around different chains (and earn fees/rewards) 
 
 The withdrawal flow is same for user transfer refund or LP liquidity withdrawal.
 
-1. User or LP requests refund or withdrawal by sending a [withdraw request](https://github.com/celer-network/sgn-v2/blob/3b35212c68/proto/sgn/cbridge/v1/tx.proto#L68-L83) to a validator (via gateway). If x/cbridge verifies that the request is valid, it will create a withdraw message for validators to sign.
-    - Note that each withdrawal request has a unique [request id](https://github.com/celer-network/sgn-v2/blob/3b35212c68/proto/sgn/cbridge/v1/tx.proto#L75), which is to make sure that each withdraw can only happen once on both SGN and the onchain smart contract.
+1. User or LP requests refund or withdrawal by sending a [withdraw request](https://github.com/celer-network/sgnv2/blob/3b35212c68/proto/sgn/cbridge/v1/tx.proto#L68-L83) to a validator (via gateway). If x/cbridge verifies that the request is valid, it will create a withdraw message for validators to sign.
+    - Note that each withdrawal request has a unique [request id](https://github.com/celer-network/sgnv2/blob/3b35212c68/proto/sgn/cbridge/v1/tx.proto#L75), which is to make sure that each withdraw can only happen once on both SGN and the onchain smart contract.
 
 2. SGN nodes see the withdraw msg and add its own signature, similar to the relay msg above.
 
@@ -114,37 +114,37 @@ Approach: Deploy a PeggedToken ([example](https://github.com/celer-network/sgn-v
 
 2. SGN relayers sync the [deposit event](https://github.com/celer-network/sgn-v2-contracts/blob/a75ac8dc8b/contracts/pegged/OriginalTokenVaultV2.sol#L31) to the x/pegbridge module.
 
-3. x/pegbridge [processes the deposit event](https://github.com/celer-network/sgn-v2/blob/3b35212c68/x/pegbridge/keeper/apply.go#L30) and [generate Mint proto msg](https://github.com/celer-network/sgn-v2/blob/3b35212c68/x/pegbridge/keeper/apply.go#L251-L275) for validators to sign.
+3. x/pegbridge [processes the deposit event](https://github.com/celer-network/sgnv2/blob/3b35212c68/x/pegbridge/keeper/apply.go#L30) and [generate Mint proto msg](https://github.com/celer-network/sgnv2/blob/3b35212c68/x/pegbridge/keeper/apply.go#L251-L275) for validators to sign.
 
 4. SGN syncer call [mint](https://github.com/celer-network/sgn-v2-contracts/blob/a75ac8dc8b/contracts/pegged/PeggedTokenBridgeV2.sol#L57) function on chain B with the signed Mint proto msg. User receives the newly minted pegged tokens.
 
-5. SGN catch the [mint event](https://github.com/celer-network/sgn-v2-contracts/blob/a75ac8dc8b/contracts/pegged/PeggedTokenBridgeV2.sol#L24), sync it to x/pegbridge to [mark the process is done](https://github.com/celer-network/sgn-v2/blob/3b35212c68/x/pegbridge/keeper/apply.go#L156-L157).
+5. SGN catch the [mint event](https://github.com/celer-network/sgn-v2-contracts/blob/a75ac8dc8b/contracts/pegged/PeggedTokenBridgeV2.sol#L24), sync it to x/pegbridge to [mark the process is done](https://github.com/celer-network/sgnv2/blob/3b35212c68/x/pegbridge/keeper/apply.go#L156-L157).
 
 ### Burn pegged token on chain B and withdraw original token on chain A
 1. User calls [burn](https://github.com/celer-network/sgn-v2-contracts/blob/a75ac8dc8b/contracts/pegged/PeggedTokenBridgeV2.sol#L109) on chain B to burn the pegged token.
 
 2. SGN relayers sync the [burn event](https://github.com/celer-network/sgn-v2-contracts/blob/a75ac8dc8b/contracts/pegged/PeggedTokenBridgeV2.sol#L33) to the x/pegbridge module
 
-3. x/pegbridge [processes the burn event](https://github.com/celer-network/sgn-v2/blob/3b35212c68/x/pegbridge/keeper/apply.go#L84) and [generate Withdraw proto msg](https://github.com/celer-network/sgn-v2/blob/3b35212c68/x/pegbridge/keeper/apply.go#L123-L125) for validators to sign.
+3. x/pegbridge [processes the burn event](https://github.com/celer-network/sgnv2/blob/3b35212c68/x/pegbridge/keeper/apply.go#L84) and [generate Withdraw proto msg](https://github.com/celer-network/sgnv2/blob/3b35212c68/x/pegbridge/keeper/apply.go#L123-L125) for validators to sign.
 
 4. SGN syncer call [withdraw](https://github.com/celer-network/sgn-v2-contracts/blob/a75ac8dc8b/contracts/pegged/OriginalTokenVaultV2.sol#L135) function on chain A with the signed Withdraw proto msg
 
-5. SGN catches the [withdraw event](https://github.com/celer-network/sgn-v2-contracts/blob/a75ac8dc8b/contracts/pegged/OriginalTokenVaultV2.sol#L40), sync it to x/pegbridge to [mark the process is done](https://github.com/celer-network/sgn-v2/blob/3b35212c68/x/pegbridge/keeper/apply.go#L173-L174).
+5. SGN catches the [withdraw event](https://github.com/celer-network/sgn-v2-contracts/blob/a75ac8dc8b/contracts/pegged/OriginalTokenVaultV2.sol#L40), sync it to x/pegbridge to [mark the process is done](https://github.com/celer-network/sgnv2/blob/3b35212c68/x/pegbridge/keeper/apply.go#L173-L174).
 
 ### Burn pegged token on chain B and mint pegged token on chain C
 1. User calls [burn](https://github.com/celer-network/sgn-v2-contracts/blob/a75ac8dc8b/contracts/pegged/PeggedTokenBridgeV2.sol#L109) on chain B to burn the pegged token, specifying chain C's chainId as `toChainId`
 
 2. SGN relayers sync the [burn event](https://github.com/celer-network/sgn-v2-contracts/blob/a75ac8dc8b/contracts/pegged/PeggedTokenBridgeV2.sol#L33) to the x/pegbridge module
 
-3. x/pegbridge [processes the burn event](https://github.com/celer-network/sgn-v2/blob/3b35212c68/x/pegbridge/keeper/apply.go#L84) and [generate mint proto msg](https://github.com/celer-network/sgn-v2/blob/3b35212c68/x/pegbridge/keeper/apply.go#L126-L128) for validators to sign.
+3. x/pegbridge [processes the burn event](https://github.com/celer-network/sgnv2/blob/3b35212c68/x/pegbridge/keeper/apply.go#L84) and [generate mint proto msg](https://github.com/celer-network/sgnv2/blob/3b35212c68/x/pegbridge/keeper/apply.go#L126-L128) for validators to sign.
 
 4. SGN syncer call [mint](https://github.com/celer-network/sgn-v2-contracts/blob/a75ac8dc8b/contracts/pegged/PeggedTokenBridgeV2.sol#L57) function on chain C with the signed Mint proto msg. User receives the newly minted pegged tokens.
 
-5. SGN catches the [mint event](https://github.com/celer-network/sgn-v2-contracts/blob/a75ac8dc8b/contracts/pegged/PeggedTokenBridgeV2.sol#L24), sync it to x/pegbridge to [mark the process is done](https://github.com/celer-network/sgn-v2/blob/3b35212c68/x/pegbridge/keeper/apply.go#L156-L157).
+5. SGN catches the [mint event](https://github.com/celer-network/sgn-v2-contracts/blob/a75ac8dc8b/contracts/pegged/PeggedTokenBridgeV2.sol#L24), sync it to x/pegbridge to [mark the process is done](https://github.com/celer-network/sgnv2/blob/3b35212c68/x/pegbridge/keeper/apply.go#L156-L157).
 
 ### SGN delegators claim fee shares on chain A
 1. Delegator requests withdrawal of fee shares via gateway.
 
-2. SGN validates the request and [generates co-signed Withdraw proto msg](https://github.com/celer-network/sgn-v2/blob/3b35212c68/x/pegbridge/keeper/msg_server.go#L193-L218).
+2. SGN validates the request and [generates co-signed Withdraw proto msg](https://github.com/celer-network/sgnv2/blob/3b35212c68/x/pegbridge/keeper/msg_server.go#L193-L218).
 
 3. Delegator get the Withdraw proto msg from gateway and call [withdraw](https://github.com/celer-network/sgn-v2-contracts/blob/a75ac8dc8b/contracts/pegged/OriginalTokenVaultV2.sol#L135) function on chain A with it.

--- a/test/README.md
+++ b/test/README.md
@@ -14,7 +14,7 @@ Follow instructions in [e2e/manual](./e2e/manual/README.md) for local manual tes
 Run the following command from the sgn-v2 repo root folder
 
 ```sh
-go test -failfast -v -timeout 30m github.com/celer-network/sgn-v2/test/e2e/singlenode
+go test -failfast -v -timeout 30m github.com/celer-network/sgnv2/test/e2e/singlenode
 ```
 
 To run a single test (e.g., staking test), run following command in `test/e2e/singlenode` folder
@@ -28,7 +28,7 @@ go test -failfast -v -run ^TestStaking$
 Run the following command from the sgn-v2 repo root folder
 
 ```sh
-go test -failfast -v -timeout 30m github.com/celer-network/sgn-v2/test/e2e/multinode
+go test -failfast -v -timeout 30m github.com/celer-network/sgnv2/test/e2e/multinode
 ```
 Logs are located at
 

--- a/test/e2e/manual/docs/live_upgrade.md
+++ b/test/e2e/manual/docs/live_upgrade.md
@@ -40,7 +40,7 @@ sgnd query gov proposal 1 --home data/node0/sgnd
 go run localnet.go -stopall
 ```
 
-2. Switch to the new code, add upgrade handler and migration code. [Example: add new staking param](https://github.com/celer-network/sgn-v2/commit/1fadc4e3f2c21b449222c24174dd13963ba805ee)
+2. Switch to the new code, add upgrade handler and migration code. [Example: add new staking param](https://github.com/celer-network/sgnv2/commit/1fadc4e3f2c21b449222c24174dd13963ba805ee)
 
 3. Rebuild container images and restart:
 

--- a/x/distribution/spec/02_state.md
+++ b/x/distribution/spec/02_state.md
@@ -19,7 +19,7 @@ In Cosmos SDK, the `FeePool` is reserved for distributions from passed community
 
 - FeePool: `0x00 | CommunitySpendProposalID -> ProtocolBuffer(FeePool)`
 
-[Protobuf reference](https://github.com/celer-network/sgn-v2/blob/7083316f71a4e794c89a737cd09eb7c1ae38106f/proto/sgn/distribution/v1/distribution.proto#L88)
+[Protobuf reference](https://github.com/celer-network/sgnv2/blob/7083316f71a4e794c89a737cd09eb7c1ae38106f/proto/sgn/distribution/v1/distribution.proto#L88)
 
 ## PreviousProposer
 
@@ -33,7 +33,7 @@ This key records the outstanding rewards for a validator.
 
 - ValidatorOutstandingRewards: `0x02 | ValEthAddrLen (1 byte) | ValEthAddr -> ProtocolBuffer(ValidatorOutstandingRewards)`
 
-[Protobuf reference](https://github.com/celer-network/sgn-v2/blob/7083316f71a4e794c89a737cd09eb7c1ae38106f/proto/sgn/distribution/v1/distribution.proto#L79)
+[Protobuf reference](https://github.com/celer-network/sgnv2/blob/7083316f71a4e794c89a737cd09eb7c1ae38106f/proto/sgn/distribution/v1/distribution.proto#L79)
 
 ## DelegatorWithdrawAddress
 
@@ -47,7 +47,7 @@ This key records the delegator starting info.
 
 - DelegatorStartingInfo: `0x04 | ValEthAddrLen (1 byte) | ValEthAddr | DelAddrLen (1 byte) | DelAddr -> ProtocolBuffer(DelegatorStartingInfo)`
 
-[Protobuf reference](https://github.com/celer-network/sgn-v2/blob/7083316f71a4e794c89a737cd09eb7c1ae38106f/proto/sgn/distribution/v1/distribution.proto#L114)
+[Protobuf reference](https://github.com/celer-network/sgnv2/blob/7083316f71a4e794c89a737cd09eb7c1ae38106f/proto/sgn/distribution/v1/distribution.proto#L114)
 
 ## ValidatorHistoricalRewards
 
@@ -55,7 +55,7 @@ This key records the historical rewards for a validator.
 
 - ValidatorHistoricalRewards: `0x05 | ValEthAddrLen (1 byte) | ValEthAddr | Period -> ProtocolBuffer(ValidatorHistoricalRewards)`
 
-[Protobuf reference](https://github.com/celer-network/sgn-v2/blob/7083316f71a4e794c89a737cd09eb7c1ae38106f/proto/sgn/distribution/v1/distribution.proto#L52)
+[Protobuf reference](https://github.com/celer-network/sgnv2/blob/7083316f71a4e794c89a737cd09eb7c1ae38106f/proto/sgn/distribution/v1/distribution.proto#L52)
 
 ## ValidatorCurrentRewards
 
@@ -63,7 +63,7 @@ This key records the rewards for a validator in the current period.
 
 - ValidatorCurrentRewards: `0x06 | ValEthAddrLen (1 byte) | ValEthAddr -> ProtocolBuffer(ValidatorCurrentRewards)`
 
-[Protobuf reference](https://github.com/celer-network/sgn-v2/blob/7083316f71a4e794c89a737cd09eb7c1ae38106f/proto/sgn/distribution/v1/distribution.proto#L64)
+[Protobuf reference](https://github.com/celer-network/sgnv2/blob/7083316f71a4e794c89a737cd09eb7c1ae38106f/proto/sgn/distribution/v1/distribution.proto#L64)
 
 ## ValidatorAccumulatedCommission
 
@@ -71,7 +71,7 @@ This key records the current accumulated commission for a validator.
 
 - ValidatorAccumulatedCommission: `0x07 | ValEthAddrLen (1 byte) | ValEthAddr -> ProtocolBuffer(ValidatorAccumulatedCommission)`
 
-[Protobuf reference](https://github.com/celer-network/sgn-v2/blob/7083316f71a4e794c89a737cd09eb7c1ae38106f/proto/sgn/distribution/v1/distribution.proto#L72)
+[Protobuf reference](https://github.com/celer-network/sgnv2/blob/7083316f71a4e794c89a737cd09eb7c1ae38106f/proto/sgn/distribution/v1/distribution.proto#L72)
 
 ## StakingRewardClaimInfo
 
@@ -79,4 +79,4 @@ This key describes the staking reward claim metadata for a delegator.
 
 - StakingRewardClaimInfo: `0x08 | DelAddr -> ProtocolBuffer(StakingRewardClaimInfo)`
 
-[Protobuf reference](https://github.com/celer-network/sgn-v2/blob/7083316f71a4e794c89a737cd09eb7c1ae38106f/proto/sgn/distribution/v1/distribution.proto#L147)
+[Protobuf reference](https://github.com/celer-network/sgnv2/blob/7083316f71a4e794c89a737cd09eb7c1ae38106f/proto/sgn/distribution/v1/distribution.proto#L147)

--- a/x/distribution/spec/04_messages.md
+++ b/x/distribution/spec/04_messages.md
@@ -11,7 +11,7 @@ Changing the withdraw address is possible only if the parameter `WithdrawAddrEna
 
 The withdraw address cannot be any of the module accounts. These accounts are blocked from being withdraw addresses by being added to the distribution keeper's `blockedAddrs` array at initialization.
 
-[Msg reference](https://github.com/celer-network/sgn-v2/blob/7083316f71a4e794c89a737cd09eb7c1ae38106f/proto/sgn/distribution/v1/tx.proto#L38)
+[Msg reference](https://github.com/celer-network/sgnv2/blob/7083316f71a4e794c89a737cd09eb7c1ae38106f/proto/sgn/distribution/v1/tx.proto#L38)
 
 ## MsgWithdrawDelegatorReward
 
@@ -29,7 +29,7 @@ Then the rewards for all the delegators for staking between periods `A` and `B` 
 
 The final calculated stake is equivalent to the actual staked coins in the delegation with a margin of error due to rounding errors.
 
-[Msg reference](https://github.com/celer-network/sgn-v2/blob/7083316f71a4e794c89a737cd09eb7c1ae38106f/proto/sgn/distribution/v1/tx.proto#L55)
+[Msg reference](https://github.com/celer-network/sgnv2/blob/7083316f71a4e794c89a737cd09eb7c1ae38106f/proto/sgn/distribution/v1/tx.proto#L55)
 
 ## MsgWithdrawValidatorCommission
 
@@ -38,7 +38,7 @@ The commission is calculated in every block during `BeginBlock`, so no iteration
 The amount withdrawn is deducted from the `ValidatorOutstandingRewards` variable for the validator.
 Only integer amounts can be sent. If the accumulated awards have decimals, the amount is truncated before the withdrawal is sent, and the remainder is left to be withdrawn later.
 
-[Msg reference](https://github.com/celer-network/sgn-v2/blob/7083316f71a4e794c89a737cd09eb7c1ae38106f/proto/sgn/distribution/v1/tx.proto#L72)
+[Msg reference](https://github.com/celer-network/sgnv2/blob/7083316f71a4e794c89a737cd09eb7c1ae38106f/proto/sgn/distribution/v1/tx.proto#L72)
 
 ## MsgFundCommunityPool
 
@@ -46,19 +46,19 @@ This message sends coins directly from the sender to the community pool.
 
 The message fails if the amount cannot be transferred from the sender to the distribution module account.
 
-[Msg reference](https://github.com/celer-network/sgn-v2/blob/7083316f71a4e794c89a737cd09eb7c1ae38106f/proto/sgn/distribution/v1/tx.proto#L87)
+[Msg reference](https://github.com/celer-network/sgnv2/blob/7083316f71a4e794c89a737cd09eb7c1ae38106f/proto/sgn/distribution/v1/tx.proto#L87)
 
 ## MsgClaimAllStakingReward
 
 This message claims rewards for a delegator from all the validators they have delegated to.
 
-[Msg reference](https://github.com/celer-network/sgn-v2/blob/7083316f71a4e794c89a737cd09eb7c1ae38106f/proto/sgn/distribution/v1/tx.proto#L102)
+[Msg reference](https://github.com/celer-network/sgnv2/blob/7083316f71a4e794c89a737cd09eb7c1ae38106f/proto/sgn/distribution/v1/tx.proto#L102)
 
 ## MsgSignStakingReward
 
 This message is sent by the validators to co-sign staking rewards upon seeing a valid claim from a user.
 
-[Msg reference](https://github.com/celer-network/sgn-v2/blob/7083316f71a4e794c89a737cd09eb7c1ae38106f/proto/sgn/distribution/v1/tx.proto#L116)
+[Msg reference](https://github.com/celer-network/sgnv2/blob/7083316f71a4e794c89a737cd09eb7c1ae38106f/proto/sgn/distribution/v1/tx.proto#L116)
 
 ## Common Operations
 
@@ -69,4 +69,4 @@ These operations take place during many different messages.
 Each time a delegation is changed, the rewards are withdrawn and the delegation is reinitialized.
 Initializing a delegation increments the validator period and keeps track of the starting period of the delegation.
 
-[Code reference](https://github.com/celer-network/sgn-v2/blob/7083316f71a4e794c89a737cd09eb7c1ae38106f/x/distribution/keeper/delegation.go#L15)
+[Code reference](https://github.com/celer-network/sgnv2/blob/7083316f71a4e794c89a737cd09eb7c1ae38106f/x/distribution/keeper/delegation.go#L15)

--- a/x/farming/spec/02_state.md
+++ b/x/farming/spec/02_state.md
@@ -16,7 +16,7 @@ When coins are distributed from the pool they are truncated back to
 
 - FarmingPool: `0x01 | PoolName -> ProtocolBuffer(FarmingPool)`
 
-[Protobuf reference](https://github.com/celer-network/sgn-v2/blob/7083316f71a4e794c89a737cd09eb7c1ae38106f/proto/sgn/farming/v1/farming.proto#L27)
+[Protobuf reference](https://github.com/celer-network/sgnv2/blob/7083316f71a4e794c89a737cd09eb7c1ae38106f/proto/sgn/farming/v1/farming.proto#L27)
 
 ## AddressInFarmingPool
 
@@ -30,7 +30,7 @@ This key tracks the stake of a user in a farming pool.
 
 - StakeInfo: `0x03 | UserAddr | PoolName -> ProtocolBuffer(StakeInfo)`
 
-[Protobuf reference](https://github.com/celer-network/sgn-v2/blob/7083316f71a4e794c89a737cd09eb7c1ae38106f/proto/sgn/farming/v1/farming.proto#L63)
+[Protobuf reference](https://github.com/celer-network/sgnv2/blob/7083316f71a4e794c89a737cd09eb7c1ae38106f/proto/sgn/farming/v1/farming.proto#L63)
 
 ## PoolHistoricalRewards
 
@@ -38,7 +38,7 @@ This key records the reward ratio of one user in a pool.
 
 - PoolHistoricalRewards: `0x04 | PoolName -> ProtocolBuffer(PoolHistoricalRewards)`
 
-[Protobuf reference](https://github.com/celer-network/sgn-v2/blob/7083316f71a4e794c89a737cd09eb7c1ae38106f/proto/sgn/farming/v1/farming.proto#L72)
+[Protobuf reference](https://github.com/celer-network/sgnv2/blob/7083316f71a4e794c89a737cd09eb7c1ae38106f/proto/sgn/farming/v1/farming.proto#L72)
 
 ## PoolCurrentRewards
 
@@ -46,7 +46,7 @@ This key records the rewards in the current period.
 
 - PoolCurrentRewards: `0x05 | PoolName -> ProtocolBuffer(PoolCurrentRewards)`
 
-[Protobuf reference](https://github.com/celer-network/sgn-v2/blob/7083316f71a4e794c89a737cd09eb7c1ae38106f/proto/sgn/farming/v1/farming.proto#L82)
+[Protobuf reference](https://github.com/celer-network/sgnv2/blob/7083316f71a4e794c89a737cd09eb7c1ae38106f/proto/sgn/farming/v1/farming.proto#L82)
 
 ## RewardClaimInfo
 
@@ -54,7 +54,7 @@ This key describes the reward claim metadata and details for a recipient.
 
 - RewardClaimInfo: `0x06 | UserAddr -> ProtocolBuffer(RewardClaimInfo)`
 
-[Protobuf reference](https://github.com/celer-network/sgn-v2/blob/7083316f71a4e794c89a737cd09eb7c1ae38106f/proto/sgn/farming/v1/farming.proto#L139)
+[Protobuf reference](https://github.com/celer-network/sgnv2/blob/7083316f71a4e794c89a737cd09eb7c1ae38106f/proto/sgn/farming/v1/farming.proto#L139)
 
 ## ERC20Token
 
@@ -62,7 +62,7 @@ This key describes an ERC20 token on a specific EVM-compatible chain.
 
 - ERC20Token: `0x07 | ChainId | Symbol -> ProtocolBuffer(ERC20Token)`
 
-[Protobuf reference](https://github.com/celer-network/sgn-v2/blob/7083316f71a4e794c89a737cd09eb7c1ae38106f/proto/sgn/common/v1/common.proto#L257)
+[Protobuf reference](https://github.com/celer-network/sgnv2/blob/7083316f71a4e794c89a737cd09eb7c1ae38106f/proto/sgn/common/v1/common.proto#L257)
 
 ## RewardContract
 
@@ -70,4 +70,4 @@ This key is used to store the info about the farming reward contracts.
 
 - RewardContract: `0x08 | ChainId -> ProtocolBuffer(ContractInfo)`
 
-[Protobuf reference](https://github.com/celer-network/sgn-v2/blob/7083316f71a4e794c89a737cd09eb7c1ae38106f/proto/sgn/common/v1/common.proto#L17)
+[Protobuf reference](https://github.com/celer-network/sgnv2/blob/7083316f71a4e794c89a737cd09eb7c1ae38106f/proto/sgn/common/v1/common.proto#L17)

--- a/x/farming/spec/03_messages.md
+++ b/x/farming/spec/03_messages.md
@@ -17,19 +17,19 @@ Then the rewards for all the users for staking between periods `A` and `B` are `
 
 The final calculated stake is equivalent to the actual staked coins with a margin of error due to rounding errors.
 
-[Msg reference](https://github.com/celer-network/sgn-v2/blob/7083316f71a4e794c89a737cd09eb7c1ae38106f/proto/sgn/farming/v1/tx.proto#L23)
+[Msg reference](https://github.com/celer-network/sgnv2/blob/7083316f71a4e794c89a737cd09eb7c1ae38106f/proto/sgn/farming/v1/tx.proto#L23)
 
 ## MsgClaimAllRewards
 
 This message claims rewards for a user from all the pools they have stakes in.
 
-[Msg reference](https://github.com/celer-network/sgn-v2/blob/7083316f71a4e794c89a737cd09eb7c1ae38106f/proto/sgn/farming/v1/tx.proto#L40)
+[Msg reference](https://github.com/celer-network/sgnv2/blob/7083316f71a4e794c89a737cd09eb7c1ae38106f/proto/sgn/farming/v1/tx.proto#L40)
 
 ## MsgSignRewards
 
 This message is sent by the validators to co-sign farming rewards upon seeing a valid claim from a user.
 
-[Msg reference](https://github.com/celer-network/sgn-v2/blob/7083316f71a4e794c89a737cd09eb7c1ae38106f/proto/sgn/farming/v1/tx.proto#L62)
+[Msg reference](https://github.com/celer-network/sgnv2/blob/7083316f71a4e794c89a737cd09eb7c1ae38106f/proto/sgn/farming/v1/tx.proto#L62)
 
 ## Common Operations
 
@@ -40,4 +40,4 @@ These operations take place during different messages.
 Each time a user's stake is changed, the rewards are withdrawn and the `StakeInfo` is updated.
 Updating a `StakeInfo` increments the pool period and keeps track of the starting period of the `StakeInfo`.
 
-[Code reference](https://github.com/celer-network/sgn-v2/blob/7083316f71a4e794c89a737cd09eb7c1ae38106f/x/farming/keeper/calc.go#L174)
+[Code reference](https://github.com/celer-network/sgnv2/blob/7083316f71a4e794c89a737cd09eb7c1ae38106f/x/farming/keeper/calc.go#L174)

--- a/x/mint/spec/02_state.md
+++ b/x/mint/spec/02_state.md
@@ -10,7 +10,7 @@ The minter is a space for holding current inflation information.
 
 - Minter: `0x00 -> ProtocolBuffer(minter)`
 
-[Protobuf reference](https://github.com/celer-network/sgn-v2/blob/7083316f71a4e794c89a737cd09eb7c1ae38106f/proto/sgn/mint/v1/mint.proto#L9)
+[Protobuf reference](https://github.com/celer-network/sgnv2/blob/7083316f71a4e794c89a737cd09eb7c1ae38106f/proto/sgn/mint/v1/mint.proto#L9)
 
 ## Params
 
@@ -18,4 +18,4 @@ Minting params are held in the global params store.
 
 - Params: `mint/params -> legacy_amino(params)`
 
-[Protobuf reference](https://github.com/celer-network/sgn-v2/blob/7083316f71a4e794c89a737cd09eb7c1ae38106f/proto/sgn/mint/v1/mint.proto#L19)
+[Protobuf reference](https://github.com/celer-network/sgnv2/blob/7083316f71a4e794c89a737cd09eb7c1ae38106f/proto/sgn/mint/v1/mint.proto#L19)

--- a/x/mint/spec/03_begin_block.md
+++ b/x/mint/spec/03_begin_block.md
@@ -10,4 +10,4 @@ The block reward is paid at the beginning of each block.
 
 Calculate the provisions generated for each block based on current annual provisions. The provisions are then minted by the `mint` module's `ModuleMinterAccount` and then transferred to the `auth`'s `FeeCollector` `ModuleAccount`.
 
-[Code reference](https://github.com/celer-network/sgn-v2/blob/7083316f71a4e794c89a737cd09eb7c1ae38106f/x/mint/types/minter.go#L28)
+[Code reference](https://github.com/celer-network/sgnv2/blob/7083316f71a4e794c89a737cd09eb7c1ae38106f/x/mint/types/minter.go#L28)

--- a/x/pegbridge/spec/02_state.md
+++ b/x/pegbridge/spec/02_state.md
@@ -1,33 +1,33 @@
 # State
 keys are defined in types/keys.go
 ## State keys
-1. original token vault, `0x01 | ChainId` -> [ContractInfo](https://github.com/celer-network/sgn-v2/blob/d25f4280b1/proto/sgn/common/v1/common.proto#L17-L22)
+1. original token vault, `0x01 | ChainId` -> [ContractInfo](https://github.com/celer-network/sgnv2/blob/d25f4280b1/proto/sgn/common/v1/common.proto#L17-L22)
 
-2. pegged token bridge, `0x02 | ChainId` -> [ContractInfo](https://github.com/celer-network/sgn-v2/blob/d25f4280b1/proto/sgn/common/v1/common.proto#L17-L22)
+2. pegged token bridge, `0x02 | ChainId` -> [ContractInfo](https://github.com/celer-network/sgnv2/blob/d25f4280b1/proto/sgn/common/v1/common.proto#L17-L22)
 
-3. pair infos of original and pegged tokens, `0x03 | SrcChainId-OrigTokenAddr-DstChainId` -> [OrigPeggedPair](https://github.com/celer-network/sgn-v2/blob/d25f4280b1/proto/sgn/pegbridge/v1/pegbridge.proto#L46-L71)
+3. pair infos of original and pegged tokens, `0x03 | SrcChainId-OrigTokenAddr-DstChainId` -> [OrigPeggedPair](https://github.com/celer-network/sgnv2/blob/d25f4280b1/proto/sgn/pegbridge/v1/pegbridge.proto#L46-L71)
 
-4. index of token infos, created by pegged token, `0x04 | DstChainId-PeggedTokenAddr` -> [PeggedOrigIndex](https://github.com/celer-network/sgn-v2/blob/d25f4280b1/proto/sgn/pegbridge/v1/pegbridge.proto#L74-L80)
+4. index of token infos, created by pegged token, `0x04 | DstChainId-PeggedTokenAddr` -> [PeggedOrigIndex](https://github.com/celer-network/sgnv2/blob/d25f4280b1/proto/sgn/pegbridge/v1/pegbridge.proto#L74-L80)
 
-5. deposit info, `0x05 | DepositId` -> [DepositInfo](https://github.com/celer-network/sgn-v2/blob/d25f4280b1/proto/sgn/pegbridge/v1/pegbridge.proto#L83-L96)
+5. deposit info, `0x05 | DepositId` -> [DepositInfo](https://github.com/celer-network/sgnv2/blob/d25f4280b1/proto/sgn/pegbridge/v1/pegbridge.proto#L83-L96)
 
-6. withdraw info, `0x06 | WithdrawId` -> [WithdrawInfo](https://github.com/celer-network/sgn-v2/blob/d25f4280b1/proto/sgn/pegbridge/v1/pegbridge.proto#L145-L169)
+6. withdraw info, `0x06 | WithdrawId` -> [WithdrawInfo](https://github.com/celer-network/sgnv2/blob/d25f4280b1/proto/sgn/pegbridge/v1/pegbridge.proto#L145-L169)
 
-7. mint info, `0x07 | MintId` -> [MintInfo](https://github.com/celer-network/sgn-v2/blob/d25f4280b1/proto/sgn/pegbridge/v1/pegbridge.proto#L99-L123)
+7. mint info, `0x07 | MintId` -> [MintInfo](https://github.com/celer-network/sgnv2/blob/d25f4280b1/proto/sgn/pegbridge/v1/pegbridge.proto#L99-L123)
 
-8. burn info, `0x08 | BurnId` -> [BurnInfo](https://github.com/celer-network/sgn-v2/blob/d25f4280b1/proto/sgn/pegbridge/v1/pegbridge.proto#L126-L142)
+8. burn info, `0x08 | BurnId` -> [BurnInfo](https://github.com/celer-network/sgnv2/blob/d25f4280b1/proto/sgn/pegbridge/v1/pegbridge.proto#L126-L142)
 
-9. fee claim info, `0x09 | UserAddr | Nonce` -> [FeeClaimInfo](https://github.com/celer-network/sgn-v2/blob/d25f4280b1/proto/sgn/pegbridge/v1/pegbridge.proto#L172-L177)
+9. fee claim info, `0x09 | UserAddr | Nonce` -> [FeeClaimInfo](https://github.com/celer-network/sgnv2/blob/d25f4280b1/proto/sgn/pegbridge/v1/pegbridge.proto#L172-L177)
 
 10. total supply amount of pegged token, `0x0a | DstChainId-PeggedTokenAddr` -> big.Int bytes
 
-11. refund, `0x0b | DepositId/BurnId` -> [WithdrawOnChain](https://github.com/celer-network/sgn-v2/blob/d25f4280b1/proto/sgn/pegbridge/v1/pegbridge.proto#L210-L239)
+11. refund, `0x0b | DepositId/BurnId` -> [WithdrawOnChain](https://github.com/celer-network/sgnv2/blob/d25f4280b1/proto/sgn/pegbridge/v1/pegbridge.proto#L210-L239)
 
 12. refund claim info, `0x0c | DepositId/BurnId` -> WithdrawId/MintId
 
-13. versioned token vault, `0x11 | ChainId | Version` -> [ContractInfo](https://github.com/celer-network/sgn-v2/blob/d25f4280b1/proto/sgn/pegbridge/v1/pegbridge.proto#L25-L29)
+13. versioned token vault, `0x11 | ChainId | Version` -> [ContractInfo](https://github.com/celer-network/sgnv2/blob/d25f4280b1/proto/sgn/pegbridge/v1/pegbridge.proto#L25-L29)
 
-14. versioned token bridge, `0x12 | ChainId | Version` -> [ContractInfo](https://github.com/celer-network/sgn-v2/blob/d25f4280b1/proto/sgn/pegbridge/v1/pegbridge.proto#L25-L29)
+14. versioned token bridge, `0x12 | ChainId | Version` -> [ContractInfo](https://github.com/celer-network/sgnv2/blob/d25f4280b1/proto/sgn/pegbridge/v1/pegbridge.proto#L25-L29)
 
 15. vault version, `0x13 | ChainId | ContractAddr` -> Version
 

--- a/x/pegbridge/spec/03_messages.md
+++ b/x/pegbridge/spec/03_messages.md
@@ -1,20 +1,20 @@
 # Messages
 
 ## MsgSignMint
-This message is sent by the validators to co-sign pegbridge mint. [Msg reference](https://github.com/celer-network/sgn-v2/blob/7083316f71a4e794c89a737cd09eb7c1ae38106f/proto/sgn/pegbridge/v1/tx.proto#L35)
+This message is sent by the validators to co-sign pegbridge mint. [Msg reference](https://github.com/celer-network/sgnv2/blob/7083316f71a4e794c89a737cd09eb7c1ae38106f/proto/sgn/pegbridge/v1/tx.proto#L35)
 
 ## MsgSignWithdraw
-This message is sent by the validators to co-sign pegbridge withdraw. [Msg reference](https://github.com/celer-network/sgn-v2/blob/7083316f71a4e794c89a737cd09eb7c1ae38106f/proto/sgn/pegbridge/v1/tx.proto#L54)
+This message is sent by the validators to co-sign pegbridge withdraw. [Msg reference](https://github.com/celer-network/sgnv2/blob/7083316f71a4e794c89a737cd09eb7c1ae38106f/proto/sgn/pegbridge/v1/tx.proto#L54)
 
 ## MsgTriggerSignMint
-This message is sent by a validator to trigger re-sign pegbridge mint. [Msg reference](https://github.com/celer-network/sgn-v2/blob/7083316f71a4e794c89a737cd09eb7c1ae38106f/proto/sgn/pegbridge/v1/tx.proto#L72)
+This message is sent by a validator to trigger re-sign pegbridge mint. [Msg reference](https://github.com/celer-network/sgnv2/blob/7083316f71a4e794c89a737cd09eb7c1ae38106f/proto/sgn/pegbridge/v1/tx.proto#L72)
 
 ## MsgTriggerSignWithdraw
-This message is sent by a validator to trigger re-sign pegbridge withdraw. [Msg reference](https://github.com/celer-network/sgn-v2/blob/7083316f71a4e794c89a737cd09eb7c1ae38106f/proto/sgn/pegbridge/v1/tx.proto#L85)
+This message is sent by a validator to trigger re-sign pegbridge withdraw. [Msg reference](https://github.com/celer-network/sgnv2/blob/7083316f71a4e794c89a737cd09eb7c1ae38106f/proto/sgn/pegbridge/v1/tx.proto#L85)
 
 ## MsgClaimFee
-This message is sent by a validator or a delegator to claim pegbridge fee. [Msg reference](https://github.com/celer-network/sgn-v2/blob/7083316f71a4e794c89a737cd09eb7c1ae38106f/proto/sgn/pegbridge/v1/tx.proto#L99)
+This message is sent by a validator or a delegator to claim pegbridge fee. [Msg reference](https://github.com/celer-network/sgnv2/blob/7083316f71a4e794c89a737cd09eb7c1ae38106f/proto/sgn/pegbridge/v1/tx.proto#L99)
 
 ## MsgClaimRefund
-This message is sent by a validator or a delegator to initiate refund claiming. [Msg reference](https://github.com/celer-network/sgn-v2/blob/7083316f71a4e794c89a737cd09eb7c1ae38106f/proto/sgn/pegbridge/v1/tx.proto#L129)
+This message is sent by a validator or a delegator to initiate refund claiming. [Msg reference](https://github.com/celer-network/sgnv2/blob/7083316f71a4e794c89a737cd09eb7c1ae38106f/proto/sgn/pegbridge/v1/tx.proto#L129)
 

--- a/x/staking/spec/01_state.md
+++ b/x/staking/spec/01_state.md
@@ -15,7 +15,7 @@ Validators are elected by the delegators on the Ethereum staking contract. They 
 
 ### Validator Info
 
-The validator info is defined in this [Protobuf reference](https://github.com/celer-network/sgn-v2/blob/f9f76fb10d/proto/sgn/staking/v1/staking.proto#L13-L79). The validator info is stored in the following schema:
+The validator info is defined in this [Protobuf reference](https://github.com/celer-network/sgnv2/blob/f9f76fb10d/proto/sgn/staking/v1/staking.proto#L13-L79). The validator info is stored in the following schema:
 ```
 0x11 | ValidatorEthAddr -> ValidatorInfo
 0x12 | ValidatorSgnAddr -> ValidatorEthAddr
@@ -41,7 +41,7 @@ Each validator can set multiple additional transactor accounts that are able to 
 
 ## Delegation
 
-Delegations records the delegators' delegation states on the Ethereum staking contract. Each delegation is identified through a combination of the delegator and validator's Ethereum addresses. The delegation info is defined in this [Protobuf reference](https://github.com/celer-network/sgn-v2/blob/f9f76fb10d/proto/sgn/staking/v1/staking.proto#L85-L107), and is stored in the following schema:
+Delegations records the delegators' delegation states on the Ethereum staking contract. Each delegation is identified through a combination of the delegator and validator's Ethereum addresses. The delegation info is defined in this [Protobuf reference](https://github.com/celer-network/sgnv2/blob/f9f76fb10d/proto/sgn/staking/v1/staking.proto#L85-L107), and is stored in the following schema:
 ```
 0x31 | DelegatorEthAddr | ValidatorEthAddr -> DelegationInfo
 ```

--- a/x/staking/spec/02_messages.md
+++ b/x/staking/spec/02_messages.md
@@ -8,10 +8,10 @@ order: 2
 
 MsgSetTransactors is sent by the validator account to update the additional transactor list of the validator.
 
-[Msg reference](https://github.com/celer-network/sgn-v2/blob/f9f76fb10d/proto/sgn/staking/v1/tx.proto#L8-L19)
+[Msg reference](https://github.com/celer-network/sgnv2/blob/f9f76fb10d/proto/sgn/staking/v1/tx.proto#L8-L19)
 
 ## MsgEditDescription
 
 MsgEditDescription is sent by the validator account to update the description of the validator
 
-[Msg reference](https://github.com/celer-network/sgn-v2/blob/f9f76fb10d/proto/sgn/staking/v1/tx.proto#L21-L24)
+[Msg reference](https://github.com/celer-network/sgnv2/blob/f9f76fb10d/proto/sgn/staking/v1/tx.proto#L21-L24)

--- a/x/staking/spec/03_end_block.md
+++ b/x/staking/spec/03_end_block.md
@@ -10,7 +10,7 @@ End block calls are executed to update tendermint validator sets and validator s
 
 Validator states could be updated by the syncer module at the end of this block. Then the abci end-block of staking module scans all the validators that has been updated during this block, and return the list of tendermint validator updates.
 
-[Implementation Reference](https://github.com/celer-network/sgn-v2/blob/f9f76fb10d/x/staking/keeper/validator.go#L210-L234)
+[Implementation Reference](https://github.com/celer-network/sgnv2/blob/f9f76fb10d/x/staking/keeper/validator.go#L210-L234)
 
 ## Set Syncer
 

--- a/x/staking/spec/README.md
+++ b/x/staking/spec/README.md
@@ -9,7 +9,7 @@ parent:
 
 ## Overview
 
-The staking module manages the underlying [tendermint validators](https://docs.tendermint.com/master/nodes/validators.html) of the SGN chain by following the staking changes on the Ethereum [staking contract](https://github.com/celer-network/sgn-v2-contracts/blob/main/contracts/Staking.sol). Whenever staking status is updated on Ethereum, the [sync](../../sync) module would be informed and send instructions to update the stating module's validator and delegation states accordingly.
+The staking module manages the underlying [tendermint validators](https://docs.tendermint.com/v0.34/tendermint-core/validators.html) of the SGN chain by following the staking changes on the Ethereum [staking contract](https://github.com/celer-network/sgn-v2-contracts/blob/main/contracts/staking/Staking.sol). Whenever staking status is updated on Ethereum, the [sync](../../sync) module would be informed and send instructions to update the stating module's validator and delegation states accordingly.
 
 ## Contents
 

--- a/x/sync/spec/01_state.md
+++ b/x/sync/spec/01_state.md
@@ -6,7 +6,7 @@ order: 1
 
 ## PendingUpdate
 
-`PendingUpdate` ([Protobuf reference](https://github.com/celer-network/sgn-v2/blob/f9f76fb10d/proto/sgn/sync/v1/sync.proto#L20-L42)) records an update proposal waiting for validators' votes. It is identified by the `updateId` which automatically increase by one for each update.
+`PendingUpdate` ([Protobuf reference](https://github.com/celer-network/sgnv2/blob/f9f76fb10d/proto/sgn/sync/v1/sync.proto#L20-L42)) records an update proposal waiting for validators' votes. It is identified by the `updateId` which automatically increase by one for each update.
 ```
 0x01 | UpdateId -> PendingUpdate
 0x11 -> NextUpdateId

--- a/x/sync/spec/02_messages.md
+++ b/x/sync/spec/02_messages.md
@@ -8,10 +8,10 @@ order: 2
 
 MsgProposeUpdates is sent by the validator account to propose a list of pending updates.
 
-[Msg reference](https://github.com/celer-network/sgn-v2/blob/f9f76fb10d/proto/sgn/sync/v1/tx.proto#L10-L23)
+[Msg reference](https://github.com/celer-network/sgnv2/blob/f9f76fb10d/proto/sgn/sync/v1/tx.proto#L10-L23)
 
 ## MsgVoteUpdates
 
 MsgVoteUpdates is sent by the validator account to vote for pending updates.
 
-[Msg reference](https://github.com/celer-network/sgn-v2/blob/f9f76fb10d/proto/sgn/sync/v1/tx.proto#L25-L33)
+[Msg reference](https://github.com/celer-network/sgnv2/blob/f9f76fb10d/proto/sgn/sync/v1/tx.proto#L25-L33)

--- a/x/sync/spec/03_end_block.md
+++ b/x/sync/spec/03_end_block.md
@@ -6,4 +6,4 @@ order: 3
 
 End block calls are executed to tally votes and apply pending update proposals. For each pending update, if more than 2/3 voting power have voted yes, the update will be applied by the relevant module and then deleted. Otherwise, if the voting window of this pending update has close, the pending update will also be deleted.
 
-[Implementation Reference](https://github.com/celer-network/sgn-v2/blob/f9f76fb10d/x/sync/abci.go#L12-L48)
+[Implementation Reference](https://github.com/celer-network/sgnv2/blob/f9f76fb10d/x/sync/abci.go#L12-L48)


### PR DESCRIPTION
This PR fixes several broken links in the documentation. Most of these seem to be a result of renaming the repo from `sgn-v2` to `sgnv2` at some point. I'd suggest considering relative paths for internal links to avoid similar issues in future.